### PR TITLE
Handle azure devops urls

### DIFF
--- a/bash-git-prompt-hook.sh
+++ b/bash-git-prompt-hook.sh
@@ -124,6 +124,7 @@ function git_bash_prompt() {
 
 	# Find the origin
 	local origin_raw=$(git config --get remote.origin.url 2> /dev/null) || true
+	origin=$(echo "$origin" | sed -e 's/%[0-9a-f][0-9a-f]/¤/ig') # Replace URL encode entitites with a ¤ mark
 	if [ -z "$origin_raw" ]; then
 		origin_raw="[no origin]"
 		origin="${color_origin}[no origin]"

--- a/bash-git-prompt-hook.sh
+++ b/bash-git-prompt-hook.sh
@@ -124,7 +124,7 @@ function git_bash_prompt() {
 
 	# Find the origin
 	local origin_raw=$(git config --get remote.origin.url 2> /dev/null) || true
-	origin=$(echo "$origin" | sed -e 's/%[0-9a-f][0-9a-f]/¤/ig') # Replace URL encode entitites with a ¤ mark
+	origin_raw=$(echo "$origin_raw" | sed -e 's/%[0-9a-f][0-9a-f]/¤/ig') # Replace URL encode entitites with a ¤ mark
 	if [ -z "$origin_raw" ]; then
 		origin_raw="[no origin]"
 		origin="${color_origin}[no origin]"


### PR DESCRIPTION
Azure devops Git repos include URL encoded strings. The percentage signs mess up the origin name.